### PR TITLE
Fixed get-customer-profile.php (count of payment profile) and PaypalExpressCheckout/prior-authorization-capture.php (uninitialized request object.)

### DIFF
--- a/ApplePayTransactions/create-an-apple-pay-transaction.php
+++ b/ApplePayTransactions/create-an-apple-pay-transaction.php
@@ -1,1 +1,52 @@
+<?php
+require 'vendor/autoload.php';
 
+use net\authorize\api\contract\v1 as AnetAPI;
+use net\authorize\api\controller as AnetController;
+
+define("AUTHORIZENET_LOG_FILE", "phplog");
+$merchantAuthentication = new AnetAPI\MerchantAuthenticationType();
+$merchantAuthentication->setName("5KP3u95bQpv");
+$merchantAuthentication->setTransactionKey("4Ktq966gC55GAX7S");
+$refId = 'ref' . time();
+
+$op = new AnetAPI\OpaqueDataType();
+$op->setDataDescriptor("COMMON.APPLE.INAPP.PAYMENT");
+$op->setDataValue("eyJkYXRhIjoiQkRQTldTdE1tR2V3UVVXR2c0bzdFXC9qKzFjcTFUNzhxeVU4NGI2N2l0amNZSTh3UFlBT2hzaGpoWlBycWRVcjRYd1BNYmo0emNHTWR5KysxSDJWa1BPWStCT01GMjV1YjE5Y1g0bkN2a1hVVU9UakRsbEIxVGdTcjhKSFp4Z3A5ckNnc1NVZ2JCZ0tmNjBYS3V0WGY2YWpcL284WkliS25yS1E4U2gwb3VMQUtsb1VNbit2UHU0K0E3V0tycXJhdXo5SnZPUXA2dmhJcStIS2pVY1VOQ0lUUHlGaG1PRXRxK0grdzB2UmExQ0U2V2hGQk5uQ0hxenpXS2NrQlwvMG5xTFpSVFliRjBwK3Z5QmlWYVdIZWdoRVJmSHhSdGJ6cGVjelJQUHVGc2ZwSFZzNDhvUExDXC9rXC8xTU5kNDdrelwvcEhEY1JcL0R5NmFVTStsTmZvaWx5XC9RSk4rdFMzbTBIZk90SVNBUHFPbVhlbXZyNnhKQ2pDWmxDdXcwQzltWHpcL29iSHBvZnVJRVM4cjljcUdHc1VBUERwdzdnNjQybTRQendLRitIQnVZVW5lV0RCTlNEMnU2amJBRzMiLCJ2ZXJzaW9uIjoiRUNfdjEiLCJoZWFkZXIiOnsiYXBwbGljYXRpb25EYXRhIjoiOTRlZTA1OTMzNWU1ODdlNTAxY2M0YmY5MDYxM2UwODE0ZjAwYTdiMDhiYzdjNjQ4ZmQ4NjVhMmFmNmEyMmNjMiIsInRyYW5zYWN0aW9uSWQiOiJjMWNhZjVhZTcyZjAwMzlhODJiYWQ5MmI4MjgzNjM3MzRmODViZjJmOWNhZGYxOTNkMWJhZDlkZGNiNjBhNzk1IiwiZXBoZW1lcmFsUHVibGljS2V5IjoiTUlJQlN6Q0NBUU1HQnlxR1NNNDlBZ0V3Z2ZjQ0FRRXdMQVlIS29aSXpqMEJBUUloQVBcL1wvXC9cLzhBQUFBQkFBQUFBQUFBQUFBQUFBQUFcL1wvXC9cL1wvXC9cL1wvXC9cL1wvXC9cL1wvXC9cL01Gc0VJUFwvXC9cL1wvOEFBQUFCQUFBQUFBQUFBQUFBQUFBQVwvXC9cL1wvXC9cL1wvXC9cL1wvXC9cL1wvXC9cLzhCQ0JheGpYWXFqcVQ1N1BydlZWMm1JYThaUjBHc014VHNQWTd6ancrSjlKZ1N3TVZBTVNkTmdpRzV3U1RhbVo0NFJPZEpyZUJuMzZRQkVFRWF4ZlI4dUVzUWtmNHZPYmxZNlJBOG5jRGZZRXQ2ek9nOUtFNVJkaVl3cFpQNDBMaVwvaHBcL200N242MHA4RDU0V0s4NHpWMnN4WHM3THRrQm9ONzlSOVFJaEFQXC9cL1wvXC84QUFBQUFcL1wvXC9cL1wvXC9cL1wvXC9cLys4NXZxdHB4ZWVoUE81eXNMOFl5VlJBZ0VCQTBJQUJHbStnc2wwUFpGVFwva0RkVVNreHd5Zm84SnB3VFFRekJtOWxKSm5tVGw0REdVdkFENEdzZUdqXC9wc2hCWjBLM1RldXFEdFwvdERMYkUrOFwvbTB5Q21veHc9IiwicHVibGljS2V5SGFzaCI6IlwvYmI5Q05DMzZ1QmhlSEZQYm1vaEI3T28xT3NYMkora0pxdjQ4ek9WVmlRPSJ9LCJzaWduYXR1cmUiOiJNSUlEUWdZSktvWklodmNOQVFjQ29JSURNekNDQXk4Q0FRRXhDekFKQmdVckRnTUNHZ1VBTUFzR0NTcUdTSWIzRFFFSEFhQ0NBaXN3Z2dJbk1JSUJsS0FEQWdFQ0FoQmNsK1BmMytVNHBrMTNuVkQ5bndRUU1Ba0dCU3NPQXdJZEJRQXdKekVsTUNNR0ExVUVBeDRjQUdNQWFBQnRBR0VBYVFCQUFIWUFhUUJ6QUdFQUxnQmpBRzhBYlRBZUZ3MHhOREF4TURFd05qQXdNREJhRncweU5EQXhNREV3TmpBd01EQmFNQ2N4SlRBakJnTlZCQU1lSEFCakFHZ0FiUUJoQUdrQVFBQjJBR2tBY3dCaEFDNEFZd0J2QUcwd2daOHdEUVlKS29aSWh2Y05BUUVCQlFBRGdZMEFNSUdKQW9HQkFOQzgra2d0Z212V0YxT3pqZ0ROcmpURUJSdW9cLzVNS3ZsTTE0NnBBZjdHeDQxYmxFOXc0ZklYSkFEN0ZmTzdRS2pJWFlOdDM5ckx5eTd4RHdiXC81SWtaTTYwVFoyaUkxcGo1NVVjOGZkNGZ6T3BrM2Z0WmFRR1hOTFlwdEcxZDlWN0lTODJPdXA5TU1vMUJQVnJYVFBITmNzTTk5RVBVblBxZGJlR2M4N20wckFnTUJBQUdqWERCYU1GZ0dBMVVkQVFSUk1FK0FFSFpXUHJXdEpkN1laNDMxaENnN1lGU2hLVEFuTVNVd0l3WURWUVFESGh3QVl3Qm9BRzBBWVFCcEFFQUFkZ0JwQUhNQVlRQXVBR01BYndCdGdoQmNsK1BmMytVNHBrMTNuVkQ5bndRUU1Ba0dCU3NPQXdJZEJRQURnWUVBYlVLWUNrdUlLUzlRUTJtRmNNWVJFSW0ybCtYZzhcL0pYditHQlZRSmtPS29zY1k0aU5ERkFcL2JRbG9nZjlMTFU4NFRId05SbnN2VjNQcnY3UlRZODFncTBkdEM4elljQWFBa0NISUkzeXFNbko0QU91NkVPVzlrSmsyMzJnU0U3V2xDdEhiZkxTS2Z1U2dRWDhLWFFZdVpMazJScjYzTjhBcFhzWHdCTDNjSjB4Z2VBd2dkMENBUUV3T3pBbk1TVXdJd1lEVlFRREhod0FZd0JvQUcwQVlRQnBBRUFBZGdCcEFITUFZUUF1QUdNQWJ3QnRBaEJjbCtQZjMrVTRwazEzblZEOW53UVFNQWtHQlNzT0F3SWFCUUF3RFFZSktvWklodmNOQVFFQkJRQUVnWUJhSzNFbE9zdGJIOFdvb3NlREFCZitKZ1wvMTI5SmNJYXdtN2M2VnhuN1phc05iQXEzdEF0OFB0eSt1UUNnc3NYcVprTEE3a3oyR3pNb2xOdHY5d1ltdTlVandhcjFQSFlTK0JcL29Hbm96NTkxd2phZ1hXUnowbk1vNXkzTzFLelgwZDhDUkhBVmE4OFNyVjFhNUpJaVJldjNvU3RJcXd2NXh1WmxkYWc2VHI4dz09In0=");
+$paymentOne = new AnetAPI\PaymentType();
+$paymentOne->setOpaqueData($op);
+
+//create a transaction
+$transactionRequestType = new AnetAPI\TransactionRequestType();
+$transactionRequestType->setTransactionType( "authCaptureTransaction");
+$transactionRequestType->setAmount(151);
+$transactionRequestType->setPayment($paymentOne);
+
+$request = new AnetAPI\CreateTransactionRequest();
+$request->setMerchantAuthentication($merchantAuthentication);
+$request->setRefId( $refId);
+$request->setTransactionRequest( $transactionRequestType);
+
+$controller = new AnetController\CreateTransactionController($request);
+$response = $controller->executeWithApiResponse( \net\authorize\api\constants\ANetEnvironment::SANDBOX);
+
+if ($response != null)
+{
+    $tresponse = $response->getTransactionResponse();
+
+    if (($tresponse != null) && ($tresponse->getResponseCode()=="1") )
+    {
+        echo " AUTH CODE : " . $tresponse->getAuthCode() . "\n";
+        echo " TRANS ID  : " . $tresponse->getTransId() . "\n";
+    }
+    else
+    {
+        echo "ERROR :  Invalid response\n";
+        echo "Response : " . $response->getMessages()->getMessage()[0]->getCode() . "  " .$response->getMessages()->getMessage()[0]->getText() . "\n";
+    }
+}
+else
+{
+    echo "Null response";
+}
+?>

--- a/CustomerProfiles/get-customer-profile.php
+++ b/CustomerProfiles/get-customer-profile.php
@@ -74,7 +74,7 @@
   {
     echo "GetCustomerProfile SUCCESS : " .  "\n";
     $profileSelected = $response->getProfile();
-    $paymentProfilesSelected[] = $profileSelected->getPaymentProfiles();
+    $paymentProfilesSelected = $profileSelected->getPaymentProfiles();
     echo "Profile Has " . count($paymentProfilesSelected). " Payment Profiles" . "\n";
 
   }

--- a/PaymentTransactions/capture-funds-authorized-through-another-channel.php
+++ b/PaymentTransactions/capture-funds-authorized-through-another-channel.php
@@ -1,0 +1,55 @@
+<?php
+require 'vendor/autoload.php';
+use net\authorize\api\contract\v1 as AnetAPI;
+use net\authorize\api\controller as AnetController;
+define("AUTHORIZENET_LOG_FILE", "phplog");
+
+
+// Common setup for API credentials
+$merchantAuthentication = new AnetAPI\MerchantAuthenticationType();
+$merchantAuthentication->setName("556KThWQ6vf2");
+$merchantAuthentication->setTransactionKey("9ac2932kQ7kN2Wzq");
+$refId = "123456";
+
+$creditCard = new AnetAPI\CreditCardType();
+$creditCard->setCardNumber( "4111111111111111");
+$creditCard->setExpirationDate( "2038-12");
+
+$paymentOne = new AnetAPI\PaymentType();
+$paymentOne->setCreditCard($creditCard);
+
+$transactionRequestType = new AnetAPI\TransactionRequestType();
+$transactionRequestType->setTransactionType("captureOnlyTransaction");
+$transactionRequestType->setAmount(5.00);
+$transactionRequestType->setPayment($paymentOne);
+
+//Auth code of the previously authorized  amount
+$transactionRequestType->setAuthCode("ROHNFQ");
+
+
+$request = new AnetAPI\CreateTransactionRequest();
+$request->setMerchantAuthentication($merchantAuthentication);
+$request->setTransactionRequest( $transactionRequestType);
+
+$controller = new AnetController\CreateTransactionController($request);
+$response = $controller->executeWithApiResponse( \net\authorize\api\constants\ANetEnvironment::SANDBOX);
+
+if ($response != null)
+{
+    $tresponse = $response->getTransactionResponse();
+    if (($tresponse != null) && ($tresponse->getResponseCode()=="1") )
+    {
+        echo "Successful." . "\n";
+        echo "Capture funds authorized through another channel TRANS ID  : " . $tresponse->getTransId() . "\n";
+    }
+    else
+    {
+        echo  "Capture funds authorized through another channel ERROR: Invalid response\n";
+        echo "Response Code: " . $response->getMessages()->getMessage()[0]->getCode() . "  Response Text: " .$response->getMessages()->getMessage()[0]->getText() . "\n";
+    }
+}
+else
+{
+    echo  "Capture funds authorized through another channel NULL Response Error\n";
+}
+?>

--- a/PaymentTransactions/capture-previously-authorized-amount.php
+++ b/PaymentTransactions/capture-previously-authorized-amount.php
@@ -22,7 +22,7 @@
 
   //  First Authorize the amount
   $transactionRequestType = new AnetAPI\TransactionRequestType();
-  $transactionRequestType->setTransactionType("authOnlyTransaction");
+  $transactionRequestType->setTransactionType("priorAuthCaptureTransaction");
   $transactionRequestType->setAmount(5.00);
   $transactionRequestType->setPayment($paymentOne);
 

--- a/PaymentTransactions/update-split-tender-group.php
+++ b/PaymentTransactions/update-split-tender-group.php
@@ -6,12 +6,12 @@
   
   // Common Set Up for API Credentials
   $merchantAuthentication = new AnetAPI\MerchantAuthenticationType();
-  $merchantAuthentication->setName( "556KThWQ6vf2"); 
-  $merchantAuthentication->setTransactionKey("9ac2932kQ7kN2Wzq");
+  $merchantAuthentication->setName( "8V4xFm3z");
+  $merchantAuthentication->setTransactionKey("655AS4Ek7TJ42snq");
 
   $request = new AnetAPI\UpdateSplitTenderGroupRequest();
   $request->setMerchantAuthentication($merchantAuthentication);
-  $request->setSplitTenderId("123456");
+  $request->setSplitTenderId("116468");
   $request->setSplitTenderStatus("voided");
 
   $controller = new AnetController\UpdateSplitTenderGroupController($request);
@@ -20,7 +20,7 @@
   
   if (($response != null) && ($response->getMessages()->getResultCode() == "Ok") )
   {
-      echo "SUCCESS" . $response->getMessages()->getMessage()[0]->getCode() . "  " .$response->getMessages()->getMessage()[0]->getText() . "\n";
+      echo "SUCCESS : " . $response->getMessages()->getMessage()[0]->getCode() . "  " .$response->getMessages()->getMessage()[0]->getText() . "\n";
    }
   else
   {

--- a/PaymentTransactions/update-split-tender-group.php
+++ b/PaymentTransactions/update-split-tender-group.php
@@ -25,6 +25,6 @@
   else
   {
       echo "ERROR :  Invalid response\n";
-      echo "Response : " . $response->getMessages()->getMessage()[0]->getCode() . "  " .$response->getMessages()->getMessage()[0]->getText() . "\n";   
+      echo "Response Code : " . $response->getMessages()->getMessage()[0]->getCode() . " Resposne text: " .$response->getMessages()->getMessage()[0]->getText() . "\n";
   }
   ?>

--- a/PaypalExpressCheckout/prior-authorization-capture.php
+++ b/PaypalExpressCheckout/prior-authorization-capture.php
@@ -22,6 +22,7 @@
   $transactionRequest->setAmount(floatval(19.45));
   $transactionRequest->setRefTransId(2241687191);
 
+  $request = new AnetAPI\CreateTransactionRequest();
   $request->setMerchantAuthentication($merchantAuthentication);
   $request->setRefId( $refId);
   $request->setTransactionRequest($transactionRequest);


### PR DESCRIPTION
correct count of payment profiles of customer. Earlier it was always 1.