### PR TITLE
Renamed method name in create-customer-profile-with-accept-nonce

### DIFF
--- a/CustomerProfiles/create-customer-profile-with-accept-nonce.php
+++ b/CustomerProfiles/create-customer-profile-with-accept-nonce.php
@@ -5,7 +5,7 @@
 
   define("AUTHORIZENET_LOG_FILE", "phplog");
 
-  function createCustomerProfile($email){
+  function createCustomerProfileWithAcceptNonce($email){
 	  
 	  // Common setup for API credentials
 	  $merchantAuthentication = new AnetAPI\MerchantAuthenticationType();
@@ -71,5 +71,5 @@
 	  return $response;
   }
   if(!defined('DONT_RUN_SAMPLES'))
-      createCustomerProfile("test123@test.com");
+      createCustomerProfileWithAcceptNonce("test123@test.com");
 ?>


### PR DESCRIPTION
Unique method names are required by test-runner