### PR TITLE
Add examples of adding an address to auth and charge transactions / change local date format in get-settled-batch-list

### DIFF
--- a/PaymentTransactions/authorize-credit-card.php
+++ b/PaymentTransactions/authorize-credit-card.php
@@ -37,7 +37,7 @@
 
     // Create a TransactionRequestType object
     $transactionRequestType = new AnetAPI\TransactionRequestType();
-    $transactionRequestType->setTransactionType( "authCaptureTransaction"); 
+    $transactionRequestType->setTransactionType( "authOnlyTransaction"); 
     $transactionRequestType->setAmount($amount);
     $transactionRequestType->setOrder($order);
     $transactionRequestType->setPayment($paymentOne);

--- a/PaymentTransactions/authorize-credit-card.php
+++ b/PaymentTransactions/authorize-credit-card.php
@@ -21,11 +21,27 @@
     $paymentOne = new AnetAPI\PaymentType();
     $paymentOne->setCreditCard($creditCard);
 
-    //create a transaction
+    $order = new AnetAPI\OrderType();
+    $order->setDescription("New Item");
+
+    // Set the customer's Bill To address
+    $customerAddress = new AnetAPI\CustomerAddressType();
+    $customerAddress->setFirstName("Ellen");
+    $customerAddress->setLastName("Johnson");
+    $customerAddress->setCompany("Souveniropolis");
+    $customerAddress->setAddress("14 Main Street");
+    $customerAddress->setCity("Pecan Springs");
+    $customerAddress->setState("TX");
+    $customerAddress->setZip("44628");
+    $customerAddress->setCountry("USA");
+
+    // Create a TransactionRequestType object
     $transactionRequestType = new AnetAPI\TransactionRequestType();
-    $transactionRequestType->setTransactionType( "authOnlyTransaction"); 
+    $transactionRequestType->setTransactionType( "authCaptureTransaction"); 
     $transactionRequestType->setAmount($amount);
+    $transactionRequestType->setOrder($order);
     $transactionRequestType->setPayment($paymentOne);
+    $transactionRequestType->setBillTo($customerAddress);
 
     $request = new AnetAPI\CreateTransactionRequest();
     $request->setMerchantAuthentication($merchantAuthentication);
@@ -34,6 +50,7 @@
 
     $controller = new AnetController\CreateTransactionController($request);
     $response = $controller->executeWithApiResponse( \net\authorize\api\constants\ANetEnvironment::SANDBOX);
+
 
     if ($response != null)
     {
@@ -84,5 +101,5 @@
     return $response;
   }
   if(!defined('DONT_RUN_SAMPLES'))
-    authorizeCreditCard( 23.32);
+    authorizeCreditCard(\SampleCode\Constants::SAMPLE_AMOUNT);
 ?>

--- a/PaymentTransactions/charge-credit-card.php
+++ b/PaymentTransactions/charge-credit-card.php
@@ -1,90 +1,104 @@
 <?php
   require 'vendor/autoload.php';
+
   use net\authorize\api\contract\v1 as AnetAPI;
   use net\authorize\api\controller as AnetController;
 
   define("AUTHORIZENET_LOG_FILE", "phplog");
 
   function chargeCreditCard($amount){
-      // Common setup for API credentials
-      $merchantAuthentication = new AnetAPI\MerchantAuthenticationType();
-      $merchantAuthentication->setName(\SampleCode\Constants::MERCHANT_LOGIN_ID);
-      $merchantAuthentication->setTransactionKey(\SampleCode\Constants::MERCHANT_TRANSACTION_KEY);
-      $refId = 'ref' . time();
+    // Common setup for API credentials
+    $merchantAuthentication = new AnetAPI\MerchantAuthenticationType();
+    $merchantAuthentication->setName(\SampleCode\Constants::MERCHANT_LOGIN_ID);
+    $merchantAuthentication->setTransactionKey(\SampleCode\Constants::MERCHANT_TRANSACTION_KEY);
+    $refId = 'ref' . time();
 
-      // Create the payment data for a credit card
-      $creditCard = new AnetAPI\CreditCardType();
-      $creditCard->setCardNumber("4111111111111111");
-      $creditCard->setExpirationDate("1226");
-      $creditCard->setCardCode("123");
-      $paymentOne = new AnetAPI\PaymentType();
-      $paymentOne->setCreditCard($creditCard);
+    // Create the payment data for a credit card
+    $creditCard = new AnetAPI\CreditCardType();
+    $creditCard->setCardNumber("4111111111111111");
+    $creditCard->setExpirationDate("1226");
+    $creditCard->setCardCode("123");
+    $paymentOne = new AnetAPI\PaymentType();
+    $paymentOne->setCreditCard($creditCard);
 
-      $order = new AnetAPI\OrderType();
-      $order->setDescription("New Item");
+    $order = new AnetAPI\OrderType();
+    $order->setDescription("New Item");
 
-      //create a transaction
-      $transactionRequestType = new AnetAPI\TransactionRequestType();
-      $transactionRequestType->setTransactionType( "authCaptureTransaction"); 
-      $transactionRequestType->setAmount($amount);
-      $transactionRequestType->setOrder($order);
-      $transactionRequestType->setPayment($paymentOne);
-      
+    // Set the customer's Bill To address
+    $customerAddress = new AnetAPI\CustomerAddressType();
+    $customerAddress->setFirstName("Ellen");
+    $customerAddress->setLastName("Johnson");
+    $customerAddress->setCompany("Souveniropolis");
+    $customerAddress->setAddress("14 Main Street");
+    $customerAddress->setCity("Pecan Springs");
+    $customerAddress->setState("TX");
+    $customerAddress->setZip("44628");
+    $customerAddress->setCountry("USA");
 
-      $request = new AnetAPI\CreateTransactionRequest();
-      $request->setMerchantAuthentication($merchantAuthentication);
-      $request->setRefId( $refId);
-      $request->setTransactionRequest( $transactionRequestType);
-      $controller = new AnetController\CreateTransactionController($request);
-      $response = $controller->executeWithApiResponse( \net\authorize\api\constants\ANetEnvironment::SANDBOX);
-      
+    // Create a TransactionRequestType object
+    $transactionRequestType = new AnetAPI\TransactionRequestType();
+    $transactionRequestType->setTransactionType( "authCaptureTransaction"); 
+    $transactionRequestType->setAmount($amount);
+    $transactionRequestType->setOrder($order);
+    $transactionRequestType->setPayment($paymentOne);
+    $transactionRequestType->setBillTo($customerAddress);
 
-      if ($response != null)
+    $request = new AnetAPI\CreateTransactionRequest();
+    $request->setMerchantAuthentication($merchantAuthentication);
+    $request->setRefId( $refId);
+    $request->setTransactionRequest( $transactionRequestType);
+
+    $controller = new AnetController\CreateTransactionController($request);
+    $response = $controller->executeWithApiResponse( \net\authorize\api\constants\ANetEnvironment::SANDBOX);
+    
+
+    if ($response != null)
+    {
+      if($response->getMessages()->getResultCode() == \SampleCode\Constants::RESPONSE_OK)
       {
-        if($response->getMessages()->getResultCode() == \SampleCode\Constants::RESPONSE_OK)
+        $tresponse = $response->getTransactionResponse();
+        
+        if ($tresponse != null && $tresponse->getMessages() != null)   
         {
-          $tresponse = $response->getTransactionResponse();
-          
-	        if ($tresponse != null && $tresponse->getMessages() != null)   
-          {
-            echo " Transaction Response code : " . $tresponse->getResponseCode() . "\n";
-            echo "Charge Credit Card AUTH CODE : " . $tresponse->getAuthCode() . "\n";
-            echo "Charge Credit Card TRANS ID  : " . $tresponse->getTransId() . "\n";
-            echo " Code : " . $tresponse->getMessages()[0]->getCode() . "\n"; 
-	          echo " Description : " . $tresponse->getMessages()[0]->getDescription() . "\n";
-          }
-          else
-          {
-            echo "Transaction Failed \n";
-            if($tresponse->getErrors() != null)
-            {
-              echo " Error code  : " . $tresponse->getErrors()[0]->getErrorCode() . "\n";
-              echo " Error message : " . $tresponse->getErrors()[0]->getErrorText() . "\n";            
-            }
-          }
+          echo " Transaction Response code : " . $tresponse->getResponseCode() . "\n";
+          echo "Charge Credit Card AUTH CODE : " . $tresponse->getAuthCode() . "\n";
+          echo "Charge Credit Card TRANS ID  : " . $tresponse->getTransId() . "\n";
+          echo " Code : " . $tresponse->getMessages()[0]->getCode() . "\n"; 
+          echo " Description : " . $tresponse->getMessages()[0]->getDescription() . "\n";
         }
         else
         {
           echo "Transaction Failed \n";
-          $tresponse = $response->getTransactionResponse();
-          if($tresponse != null && $tresponse->getErrors() != null)
+          if($tresponse->getErrors() != null)
           {
             echo " Error code  : " . $tresponse->getErrors()[0]->getErrorCode() . "\n";
-            echo " Error message : " . $tresponse->getErrors()[0]->getErrorText() . "\n";                      
+            echo " Error message : " . $tresponse->getErrors()[0]->getErrorText() . "\n";            
           }
-          else
-          {
-            echo " Error code  : " . $response->getMessages()->getMessage()[0]->getCode() . "\n";
-            echo " Error message : " . $response->getMessages()->getMessage()[0]->getText() . "\n";
-          }
-        }      
+        }
       }
       else
       {
-        echo  "No response returned \n";
-      }
+        echo "Transaction Failed \n";
+        $tresponse = $response->getTransactionResponse();
+        
+        if($tresponse != null && $tresponse->getErrors() != null)
+        {
+          echo " Error code  : " . $tresponse->getErrors()[0]->getErrorCode() . "\n";
+          echo " Error message : " . $tresponse->getErrors()[0]->getErrorText() . "\n";                      
+        }
+        else
+        {
+          echo " Error code  : " . $response->getMessages()->getMessage()[0]->getCode() . "\n";
+          echo " Error message : " . $response->getMessages()->getMessage()[0]->getText() . "\n";
+        }
+      }      
+    }
+    else
+    {
+      echo  "No response returned \n";
+    }
 
-      return $response;
+    return $response;
   }
   if(!defined('DONT_RUN_SAMPLES'))
       chargeCreditCard(\SampleCode\Constants::SAMPLE_AMOUNT);

--- a/TransactionReporting/get-settled-batch-list.php
+++ b/TransactionReporting/get-settled-batch-list.php
@@ -39,7 +39,7 @@
   		echo "\n\n";
           echo "Batch ID: " . $batch->getBatchId() . "\n";
   		echo "Batch settled on (UTC): " . $batch->getSettlementTimeUTC()->format('r') . "\n";
-  		echo "Batch settled on (Local): " . $batch->getSettlementTimeLocal()->format('r') . "\n";
+  		echo "Batch settled on (Local): " . $batch->getSettlementTimeLocal()->format('D, d M Y H:i:s') . "\n";
   		echo "Batch settlement state: " . $batch->getSettlementState() . "\n";
   		echo "Batch market type: " . $batch->getMarketType() . "\n";
   		echo "Batch product: " . $batch->getProduct() . "\n";


### PR DESCRIPTION
I unified the samples for authorize-credit-card and charge-credit-card, and then added an example of adding a BillTo address to each. I also changed the date format for the local date in get-settled-batch-list. We previously used format('r'), but that's misleading since it displays a time zone offset of +0000. We get the local date in the API response, but we don't have any indication of what time zone that's in, so we shouldn't display any time zone info at all for the local date.