### PR TITLE
Changes to make PHP 5.6 the minimum

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-    - 5.5
     - 5.6
     - 7.0
     - 7.1

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The samples are all completely independent and self-contained. You can analyze t
 
 You can also run each sample directly from the command line.
 
-## Running the Samples
+## Running the Samples From the Command Line
 Clone this repository.
 ```
     $ git clone https://github.com/AuthorizeNet/sample-code-php.git

--- a/composer.json
+++ b/composer.json
@@ -1,9 +1,9 @@
 {
   "require": {
-  "php": ">=5.5",
+  "php": ">=5.6",
   "ext-curl": "*",
   "phpunit/phpunit": "~4.8||~6.0",
-  "authorizenet/authorizenet": "1.9.3"
+  "authorizenet/authorizenet": ">=1.9.3 || <2.0"
   },
   "autoload": {
     "classmap": ["constants"]


### PR DESCRIPTION
changed composer.json and travis.yml to drop php 5.5 support. Also changed composer.json to allow composer to install newer SDK releases if available.